### PR TITLE
docs(quick-start): fix datafileUrl typo

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -203,9 +203,9 @@ If you already have the datafile content available, you can initialize the SDK a
 // your-app/index.js
 import { createInstance } from "@featurevisor/sdk";
 
-const datafileURL =
+const datafileUrl =
   "https://cdn.yoursite.com/production/datafile-tag-all.json";
-const datafileContent = await fetch(datafileURL).then((res) => res.json());
+const datafileContent = await fetch(datafileUrl).then((res) => res.json());
 
 const sdk = createInstance({
   datafile: datafileContent,
@@ -220,11 +220,11 @@ If you want to delegate the responsibility of fetching the datafile to the SDK, 
 // your-app/index.js
 import { createInstance } from "@featurevisor/sdk";
 
-const datafileURL =
+const datafileUrl =
   "https://cdn.yoursite.com/production/datafile-tag-all.json";
 
 const sdk = createInstance({
-  datafileUrl: datafileUrl,
+  datafileUrl,
   onReady: function () {
     // datafile has been fetched successfully,
     // and you can start using the SDK


### PR DESCRIPTION
Fixed a typo on the `datafileUrl` variable in the `quick-start.md` file.